### PR TITLE
MSBuild fix for x86 disassembler project reference

### DIFF
--- a/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
+++ b/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
@@ -5,8 +5,8 @@
     <OutputType>Exe</OutputType>
     <AssemblyTitle>BenchmarkDotNet.Disassembler.x86</AssemblyTitle>
     <AssemblyName>BenchmarkDotNet.Disassembler.x86</AssemblyName>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
+    <PlatformTarget>x86</PlatformTarget>
     <SuppressNETCoreSdkPreviewMessage>True</SuppressNETCoreSdkPreviewMessage>
     <DefineConstants>$(DefineConstants);CLRMDV1</DefineConstants>
   </PropertyGroup>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT' AND '$(UseMonoRuntime)' != 'true' ">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -446,7 +446,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         {
             return baseJob
                 .WithRuntime(runtime)
-                .WithToolchain(MonoToolchain.From(new NetCoreAppSettings(msBuildMoniker, msBuildMoniker, runtime.Name, options.CliPath?.FullName, options.RestorePath?.FullName)));
+                .WithToolchain(MonoToolchain.From(new NetCoreAppSettings(msBuildMoniker, null, runtime.Name, options.CliPath?.FullName, options.RestorePath?.FullName)));
         }
 
         private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker)


### PR DESCRIPTION
fixes:
* don't include diassemblers project reference when publishing for Mono
* don't pass moniker as RuntimeFrameworkVersion as it breaks the build from command line
* keep building x86 as x86

```cmd
dotnet run -c Release -f net6.0 --filter *IntroBasic.* --project .\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Samples.csproj --job dry --runtimes net6.0 mono6.0
```

![image](https://user-images.githubusercontent.com/6011991/196788697-25cad099-d9c7-4c7e-8ceb-fe92f6718a86.png)
